### PR TITLE
replace rather than merge on update

### DIFF
--- a/lib/elasticsearchHandler.js
+++ b/lib/elasticsearchHandler.js
@@ -141,13 +141,11 @@ ElasticsearchStore.prototype.search = function(request, callback) {
  */
 ElasticsearchStore.prototype.update = function(request, partialResource, callback) {
   var self = this;
-  self._db.update({
+  self._db.index({
     index: "jsonapi",
     type: request.params.type,
     id: request.params.id,
-    body: {
-      doc: self._formatMetaData(partialResource, "stringify")
-    }
+    body: self._formatMetaData(partialResource, "stringify")
   }, function(err) {
     if (err) {
       return callback({


### PR DESCRIPTION
Fixes #2 

Using the update API causes an elasticsearch document to be merged into the existing document, instead the document should be replaced so I changed the update function to use the index API which does just that.
