### PR TITLE
Support for JSON-style queries and configuration of elasticsearch host and index.

### DIFF
--- a/lib/elasticsearchHandler.js
+++ b/lib/elasticsearchHandler.js
@@ -49,7 +49,7 @@ ElasticsearchStore.prototype._buildQuery = function(request) {
     });
 
     if (filterString.length > 0) {
-      var queryString = filterString.join(") AND (");
+      var queryString = "(" + filterString.join(") AND (") + ")";
       return {query_string: {query: queryString}};
     }
   }

--- a/lib/elasticsearchHandler.js
+++ b/lib/elasticsearchHandler.js
@@ -1,5 +1,4 @@
 "use strict";
-var ElasticsearchStore = module.exports = function ElasticsearchStore() { };
 
 var async = require("async");
 var debug = require("debug")("jsonApi:store:elasticsearch");
@@ -8,6 +7,13 @@ var _ = {
   assign: require("lodash.assign")
 };
 
+
+var ElasticsearchStore = module.exports = function ElasticsearchStore(config) {
+  this.config = _.assign({
+    host: "localhost:9200",
+    index: 'jsonapi'
+  }, config);
+};
 
 ElasticsearchStore.prototype.ready = false;
 
@@ -146,7 +152,7 @@ ElasticsearchStore.prototype._getSource = function(ressource) {
 ElasticsearchStore.prototype.initialise = function(resourceConfig) {
   var self = this;
   var clientConfig = {
-    host: "http://localhost:9200"
+    host: self.config.host
   };
   var client = new elasticsearch.Client(JSON.parse(JSON.stringify(clientConfig)));
   if (!client) {
@@ -160,14 +166,14 @@ ElasticsearchStore.prototype.initialise = function(resourceConfig) {
 
 ElasticsearchStore.prototype.populate = function(callback) {
   var self = this;
-  self._db.indices.delete({ index: "jsonapi" }, function(err) {
+  self._db.indices.delete({ index: self.config.index }, function(err) {
     if (err) console.log("Error dropping index?", err.message);
 
-    self._db.indices.create({ index: "jsonapi" }, function(err1) {
+    self._db.indices.create({ index: self.config.index }, function(err1) {
       if (err1) console.log("Error creating index?", err1);
 
       var mappingRequest = {
-        index: "jsonapi",
+        index: self.config.index,
         type: self.resourceConfig.resource,
         body: self._generateMappingFor(self.resourceConfig)
       };
@@ -192,7 +198,7 @@ ElasticsearchStore.prototype.populate = function(callback) {
 ElasticsearchStore.prototype.create = function(request, newResource, callback) {
   var self = this;
   self._db.index({
-    index: "jsonapi",
+    index: self.config.index,
     type: newResource.type,
     id: newResource.id,
     body: newResource,
@@ -216,7 +222,7 @@ ElasticsearchStore.prototype.create = function(request, newResource, callback) {
 ElasticsearchStore.prototype.find = function(request, callback) {
   var self = this;
   self._db.get({
-    index: "jsonapi",
+    index: self.config.index,
     type: request.params.type,
     id: request.params.id
   }, function(err, theResource) {
@@ -240,7 +246,7 @@ ElasticsearchStore.prototype.find = function(request, callback) {
 ElasticsearchStore.prototype.search = function(request, callback) {
   var self = this;
   var params = _.assign({
-    index: "jsonapi",
+    index: self.config.index,
     type: request.params.type,
     body: {
       query: self._buildQuery(request)
@@ -311,7 +317,7 @@ ElasticsearchStore.prototype.update = function(request, partialResource, callbac
 ElasticsearchStore.prototype.delete = function(request, callback) {
   var self = this;
   self._db.delete({
-    index: "jsonapi",
+    index: self.config.index,
     type: request.params.type,
     id: request.params.id
   }, function(err, response) {

--- a/lib/elasticsearchHandler.js
+++ b/lib/elasticsearchHandler.js
@@ -11,7 +11,7 @@ var _ = {
 var ElasticsearchStore = module.exports = function ElasticsearchStore(config) {
   this.config = _.assign({
     host: "localhost:9200",
-    index: 'jsonapi'
+    index: "jsonapi"
   }, config);
 };
 
@@ -54,7 +54,7 @@ ElasticsearchStore.prototype._buildQuery = function(request) {
     }
   }
 
-  return {match_all : {}};
+  return {match_all: {}};
 };
 
 ElasticsearchStore.prototype._applySort = function(request) {
@@ -144,7 +144,7 @@ ElasticsearchStore.prototype._getSource = function(ressource) {
   }
 
   return source;
-}
+};
 
 
 /**

--- a/lib/elasticsearchHandler.js
+++ b/lib/elasticsearchHandler.js
@@ -50,11 +50,11 @@ ElasticsearchStore.prototype._buildQuery = function(request) {
 
     if (filterString.length > 0) {
       var queryString = "(" + filterString.join(") AND (") + ")";
-      return {query_string: {query: queryString}};
+      return {query_string: {query: queryString}}; // eslint-disable-line camelcase
     }
   }
 
-  return {match_all: {}};
+  return {match_all: {}}; // eslint-disable-line camelcase
 };
 
 ElasticsearchStore.prototype._applySort = function(request) {

--- a/lib/elasticsearchHandler.js
+++ b/lib/elasticsearchHandler.js
@@ -20,40 +20,41 @@ ElasticsearchStore.prototype.ready = false;
 ElasticsearchStore.prototype._buildQuery = function(request) {
   var self = this;
 
-  if (!request.params.filter) return {match_all : {}};
+  if (request.params.filter) {
+    var filterString = Object.keys(request.params.filter).map(function (attribute) {
+      var attributeConfig = self.resourceConfig.attributes[attribute];
+      // If the filter attribute doens't exist, skip it
+      if (!attributeConfig) return null;
 
-  var filterString = Object.keys(request.params.filter).map(function(attribute) {
-    var attributeConfig = self.resourceConfig.attributes[attribute];
-    // If the filter attribute doens't exist, skip it
-    if (!attributeConfig) return null;
+      var values = request.params.filter[attribute];
+      if (!values) return null;
 
-    var values = request.params.filter[attribute];
-    if (!values) return null;
+      // Relationships need to be queried via .id
+      if (attributeConfig._settings) {
+        attribute += ".id";
+        // Filters on nested resources should be skipped
+        if (values instanceof Object) return null;
+      }
 
-    // Relationships need to be queried via .id
-    if (attributeConfig._settings) {
-      attribute += ".id";
-      // Filters on nested resources should be skipped
-      if (values instanceof Object) return null;
+      // Coerce values to an array to simplify the logic
+      values = [].concat(values);
+      values = values.map(function (value) {
+        if (value[0] === ":" || (value[0] === "~")) return value.substring(1);
+        return value;
+      }).join(" OR ");
+
+      return attribute + ":(" + values + ")";
+    }).filter(function (value) {
+      return value !== null;
+    });
+
+    if (filterString.length > 0) {
+      var queryString = filterString.join(") AND (");
+      return {query_string: {query: queryString}};
     }
-
-    // Coerce values to an array to simplify the logic
-    values = [].concat(values);
-    values = values.map(function(value) {
-      if (value[0] === ":" || (value[0] === "~")) return value.substring(1);
-      return value;
-    }).join(" OR ");
-
-    return attribute + ":(" + values + ")";
-  }).filter(function(value) {
-    return value !== null;
-  });
-  if (filterString.length > 0) {
-    queryString = filterString.join(") AND (");
   }
 
-
-  return {query_string: {query: queryString}};
+  return {match_all : {}};
 };
 
 ElasticsearchStore.prototype._applySort = function(request) {

--- a/lib/elasticsearchHandler.js
+++ b/lib/elasticsearchHandler.js
@@ -14,10 +14,8 @@ ElasticsearchStore.prototype.ready = false;
 ElasticsearchStore.prototype._buildQuery = function(request) {
   var self = this;
 
-  var queryString = "type:" + request.params.type;
-  if (!request.params.filter) return queryString;
+  if (!request.params.filter) return {match_all : {}};
 
-  queryString = "(" + queryString + ")";
   var filterString = Object.keys(request.params.filter).map(function(attribute) {
     var attributeConfig = self.resourceConfig.attributes[attribute];
     // If the filter attribute doens't exist, skip it
@@ -45,10 +43,11 @@ ElasticsearchStore.prototype._buildQuery = function(request) {
     return value !== null;
   });
   if (filterString.length > 0) {
-    queryString += " AND (" + filterString.join(") AND (") + ")";
+    queryString = filterString.join(") AND (");
   }
 
-  return queryString;
+
+  return {query_string: {query: queryString}};
 };
 
 ElasticsearchStore.prototype._applySort = function(request) {
@@ -126,6 +125,19 @@ ElasticsearchStore.prototype._generateMappingFor = function(resourceConfig) {
   result[resourceConfig.resource] = mapping;
   return result;
 };
+
+
+ElasticsearchStore.prototype._getSource = function(ressource) {
+  var source = ressource._source;
+  if(!source.id) {
+    source.id = ressource._id;
+  }
+  if(!source.type) {
+    source.type = ressource._type;
+  }
+
+  return source;
+}
 
 
 /**
@@ -218,7 +230,7 @@ ElasticsearchStore.prototype.find = function(request, callback) {
     }
 
     debug("find", JSON.stringify(theResource._source));
-    return callback(null, theResource._source);
+    return callback(null, self._getSource(theResource));
   });
 };
 
@@ -229,7 +241,10 @@ ElasticsearchStore.prototype.search = function(request, callback) {
   var self = this;
   var params = _.assign({
     index: "jsonapi",
-    q: self._buildQuery(request)
+    type: request.params.type,
+    body: {
+      query: self._buildQuery(request)
+    }
   }, self._applyPagination(request), self._applySort(request));
 
   debug("search", JSON.stringify(params));
@@ -251,7 +266,7 @@ ElasticsearchStore.prototype.search = function(request, callback) {
     results = results.resultSet[0].hits.hits;
     if(!(results instanceof Array)) results = [results];
     results = results.map(function(result) {
-      return result._source;
+      return self._getSource(result);
     });
 
     debug("search", JSON.stringify(results));


### PR DESCRIPTION
I adapted the `buildQuery` method to use JSON-style queries, which makes it possible to only overwrite the `buildQuery` method for customization of JSON-style queries instead of the actual `search` method. 

PR also fixes #5 and makes it possible to use another index than `jsonapi`.